### PR TITLE
Refactor unit tests to work with CSS Modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,7 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+workflows:
+  node-tests:
+    jobs:
+      - node/test

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -1,4 +1,0 @@
-## Style Guide
-
-Refer to the [AirBnb Style Guide](https://github.com/airbnb/javascript).
-

--- a/client/PhotoModule.jsx
+++ b/client/PhotoModule.jsx
@@ -14,8 +14,8 @@ class PhotoModule extends React.Component {
 
   componentDidMount() {
     const ids = window.location.pathname.split('/');
-    const productId = ids[1];
-    const styleId = ids[2];
+    const productId = ids[2];
+    const styleId = `00${ids[3]}`;
     this.fetchPhotosByStyle(productId, styleId);
     window.addEventListener('resize', this.handleResize);
   }

--- a/client/PhotoModule.test.js
+++ b/client/PhotoModule.test.js
@@ -50,7 +50,6 @@ describe('Responsive Breakpoints', () => {
     global.innerWidth = 1024;
     global.dispatchEvent(new Event('resize'));
     app.update();
-    console.log(app.debug());
     expect(app.find('.gallery')).toExist();
     expect(app.find('#gallery-modal')).toExist();
     expect(app.find('.carousel')).not.toExist();

--- a/client/PhotoModule.test.js
+++ b/client/PhotoModule.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PhotoModule from './PhotoModule.jsx';
 
-// import styles from './components/main.module.css';
-
 const app = mount(<PhotoModule />);
 
 const photos = [

--- a/client/PhotoModule.test.js
+++ b/client/PhotoModule.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PhotoModule from './PhotoModule.jsx';
 
+// import styles from './components/main.module.css';
+
 const app = mount(<PhotoModule />);
 
 const photos = [
@@ -25,17 +27,17 @@ beforeEach(async () => {
 describe('Component rendering (default 1024px width)', () => {
   it('should render Photo component and sub-components', () => {
     expect(app).toExist();
-    expect(app).toContainMatchingElement('#gallery');
+    expect(app).toContainMatchingElement('.gallery');
     expect(app).toContainMatchingElement('#gallery-modal');
   });
 
   it('should render empty gallery view by default', () => {
-    const gallery = app.find('#gallery');
+    const gallery = app.find('.gallery');
     expect(gallery.children()).toHaveLength(0);
   });
 
   it('should hide gallery modal by default', () => {
-    expect(app.find('#gallery-modal')).toHaveClassName('hidden');
+    expect(app.find('#gallery-modal')).not.toHaveClassName('active');
   });
 });
 
@@ -46,23 +48,24 @@ describe('Responsive Breakpoints', () => {
     });
   });
 
-  it('should render gallery view at width >= 640px', () => {
-    global.innerWidth = 640;
+  it('should render gallery view at width >= 1024px', () => {
+    global.innerWidth = 1024;
     global.dispatchEvent(new Event('resize'));
     app.update();
-    expect(app.find('#gallery')).toExist();
+    console.log(app.debug());
+    expect(app.find('.gallery')).toExist();
     expect(app.find('#gallery-modal')).toExist();
-    expect(app.find('#carousel')).not.toExist();
+    expect(app.find('.carousel')).not.toExist();
     expect(app.find('#carousel-modal')).not.toExist();
   });
 
-  it('should render carousel view at width < 640px', () => {
-    global.innerWidth = 639;
+  it('should render carousel view at width < 1024px', () => {
+    global.innerWidth = 1023;
     global.dispatchEvent(new Event('resize'));
     app.update();
-    expect(app.find('#gallery')).not.toExist();
+    expect(app.find('.gallery')).not.toExist();
     expect(app.find('#gallery-modal')).not.toExist();
-    expect(app.find('#carousel')).toExist();
+    expect(app.find('.carousel')).toExist();
     expect(app.find('#carousel-modal')).toExist();
   });
 });

--- a/client/components/Carousel.jsx
+++ b/client/components/Carousel.jsx
@@ -77,7 +77,7 @@ class Carousel extends React.Component {
         <div className={styles.carousel}>
           <button type="button" className={styles.prevBtn} onClick={this.prevSlide}>&#10094;</button>
           <button type="button" className={styles.nextBtn} onClick={this.nextSlide}>&#10095;</button>
-          <div className={styles.slider}>
+          <div className={styles.sliderCards}>
             {this.generateSliderCards()}
           </div>
         </div>

--- a/client/components/Carousel.test.js
+++ b/client/components/Carousel.test.js
@@ -26,29 +26,29 @@ beforeEach(() => {
 
 describe('Component rendering', () => {
   it('should render photos into photo carousel', () => {
-    const slider = carousel.find('#slider');
+    const slider = carousel.find('.sliderCards');
     expect(slider.children()).toHaveLength(9);
   });
 
   it('should only display one photo', () => {
-    const visibleCard = carousel.find('#slider .photo-card.active');
+    const visibleCard = carousel.find('.sliderCards .card.active');
     expect(visibleCard).toHaveLength(1);
   });
 
   it('should render the first photo by default', () => {
-    const card = carousel.find('#slider .photo-card').at(0);
+    const card = carousel.find('.sliderCards .card').at(0);
     expect(card).toHaveClassName('active');
   });
 });
 
 describe('Previous and next buttons', () => {
   it('should render the next photos upon next btn click', () => {
-    const nextBtn = carousel.find('.next-btn');
+    const nextBtn = carousel.find('.nextBtn');
     nextBtn.simulate('click');
-    let visibleImg = carousel.find('#slider .active > img:first-child');
+    let visibleImg = carousel.find('.sliderCards .active > img:first-child');
     expect(visibleImg.prop('data-index')).toEqual(1);
     nextBtn.simulate('click');
-    visibleImg = carousel.find('#slider .active > img:first-child');
+    visibleImg = carousel.find('.sliderCards .active > img:first-child');
     expect(visibleImg.prop('data-index')).toEqual(2);
   });
 
@@ -56,11 +56,11 @@ describe('Previous and next buttons', () => {
     carousel.setState({
       selectedIndex: 8,
     });
-    let visibleImg = carousel.find('#slider .active > img:first-child');
+    let visibleImg = carousel.find('.sliderCards .active > img:first-child');
     expect(visibleImg.prop('data-index')).toEqual(8);
-    const prevBtn = carousel.find('.prev-btn');
+    const prevBtn = carousel.find('.prevBtn');
     prevBtn.simulate('click');
-    visibleImg = carousel.find('#carousel .active > img:first-child');
+    visibleImg = carousel.find('.carousel .active > img:first-child');
     expect(visibleImg.prop('data-index')).toEqual(7);
   });
 });
@@ -75,8 +75,8 @@ describe('Carousel modal', () => {
   });
 
   it('should open the photo modal when clicking on a carousel img', () => {
-    expect(carousel.find('#carousel-modal')).toHaveClassName('hidden');
-    const card = carousel.find('#slider .photo-card.active');
+    expect(carousel.find('#carousel-modal')).not.toHaveClassName('active');
+    const card = carousel.find('.sliderCards .card.active');
     card.simulate('click');
     expect(carousel.find('#carousel-modal')).toHaveClassName('active');
   });
@@ -86,8 +86,8 @@ describe('Carousel modal', () => {
       modalActive: true,
     });
     expect(carousel.find('#carousel-modal')).toHaveClassName('active');
-    const closeBtn = carousel.find('.close-btn');
+    const closeBtn = carousel.find('.closeBtn');
     closeBtn.simulate('click');
-    expect(carousel.find('#carousel-modal')).toHaveClassName('hidden');
+    expect(carousel.find('#carousel-modal')).not.toHaveClassName('active');
   });
 });

--- a/client/components/Gallery.test.js
+++ b/client/components/Gallery.test.js
@@ -26,13 +26,13 @@ beforeEach(() => {
 
 describe('Component rendering', () => {
   it('should render photos in gallery view', () => {
-    const galleryCards = gallery.find('#gallery');
+    const galleryCards = gallery.find('.gallery');
     console.log(galleryCards.children().debug());
     expect(galleryCards.children()).toHaveLength(9);
   });
 
   it('should render a photo card with img url', () => {
-    const image = gallery.find('.photo-card img').first();
+    const image = gallery.find('.card img').first();
     console.log(image.props());
     expect(image.prop('src')).toEqual('https://ultimate-nike.s3.us-west-1.amazonaws.com/photos/main/regular/1-001.jpg');
     expect(image.prop('data-index')).toEqual(0);
@@ -47,13 +47,13 @@ describe('Gallery Modal', () => {
 
   it('should render a photo card with img url', () => {
     const modal = gallery.find('#gallery-modal');
-    const image = modal.find('.photo-card img').at(0);
+    const image = modal.find('.card img').at(0);
     expect(image.prop('src')).toEqual('https://ultimate-nike.s3.us-west-1.amazonaws.com/photos/main/regular/1-001.jpg');
     expect(image.prop('data-index')).toEqual(0);
   });
 
   it('should open the photo modal on clicking on a gallery card and scroll to right height', () => {
-    const galleryCard = gallery.find('#gallery .photo-card').first();
+    const galleryCard = gallery.find('.gallery .card').first();
     galleryCard.simulate('click', { target: { dataset: { index: 5 } } });
     expect(gallery.find('#gallery-modal')).toHaveClassName('active');
     expect(gallery.state('modalScroll')).toEqual(6440);
@@ -64,8 +64,8 @@ describe('Gallery Modal', () => {
       modalActive: true,
     });
     expect(gallery.find('#gallery-modal')).toHaveClassName('active');
-    const closeBtn = gallery.find('.close-btn');
+    const closeBtn = gallery.find('.closeBtn');
     closeBtn.simulate('click');
-    expect(gallery.find('#gallery-modal')).toHaveClassName('hidden');
+    expect(gallery.find('#gallery-modal')).not.toHaveClassName('active');
   });
 });

--- a/client/components/main.module.css
+++ b/client/components/main.module.css
@@ -28,7 +28,7 @@
   object-fit: contain;
 }
 
-.slider {
+.sliderCards {
   /* placeholder */
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5756,6 +5756,11 @@
         "har-schema": "^2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6002,6 +6007,14 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3350,6 +3350,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.11.5",
     "aws-sdk": "^2.764.0",
+    "classnames": "^2.2.6",
     "core-js": "^3.6.5",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "enzyme-adapter-react-16": "^1.15.5",
     "eslint-plugin-jest": "^24.0.2",
     "express": "^4.17.1",
+    "identity-obj-proxy": "^3.0.0",
     "jest-environment-enzyme": "^7.1.2",
     "jest-enzyme": "^7.1.2",
     "mongoose": "^5.10.7",
@@ -61,7 +62,10 @@
     "setupFilesAfterEnv": [
       "jest-enzyme"
     ],
-    "testEnvironment": "enzyme"
+    "testEnvironment": "enzyme",
+    "moduleNameMapper": {
+      "\\.(css|less)$": "identity-obj-proxy"
+    }
   },
   "snapshotSerializers": [
     "enzyme-to-json/serializer"


### PR DESCRIPTION
All the tests broke because CSS Modules changes class names.

I added some configuration settings so that Jest recognizes CSS Modules, and refactored the tests to use updated class names.